### PR TITLE
Fixes active low input bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "switch-hal"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Christopher J. McClellan <chris.mcclellan203@gmail.com>"]
 edition = "2018"
 description = "HAL and basic implementations for input and output switches (buttons, switches, leds, transistors)"

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -13,6 +13,6 @@ impl<T: InputPin> InputSwitch for Switch<T, ActiveLow> {
     type Error = <T as InputPin>::Error;
 
     fn is_active(&self) -> Result<bool, Self::Error> {
-        self.pin.is_high()
+        self.pin.is_low()
     }
 }

--- a/tests/input.rs
+++ b/tests/input.rs
@@ -45,19 +45,19 @@ mod active_low_switch {
         use super::*;
 
         #[test]
-        fn true_when_pin_high() {
+        fn false_when_pin_high() {
             let pin = Pin::with_state(State::High);
 
             let button = Switch::<_, ActiveLow>::new(pin);
-            assert_eq!(true, button.is_active().unwrap());
+            assert_eq!(false, button.is_active().unwrap());
         }
 
         #[test]
-        fn false_when_pin_low() {
+        fn  true_when_pin_low() {
             let pin = Pin::with_state(State::Low);
 
             let button = Switch::<_, ActiveLow>::new(pin);
-            assert_eq!(false, button.is_active().unwrap());
+            assert_eq!(true, button.is_active().unwrap());
         }
 
         #[test]


### PR DESCRIPTION
`Switch<_, ActiveLow>::is_active()` was returning the wrong result.
Ironically illustrates the need for this crate.